### PR TITLE
Multiple sinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
@@ -48,6 +48,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceea9c64653169f33f946debf0a41568afc4e23a4c37d29004a23b2ffbfb4034"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -80,9 +101,52 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f1e8a972137fad81e2a1a60b86ff17ce0338f8017264e45a9723d0083c39a1"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da31c0ed7b4690e2c78fe4b880d21cd7db04a346ebc658b4270251b695437f17"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+]
 
 [[package]]
 name = "backtrace"
@@ -100,6 +164,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bindgen"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,7 +178,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap 2.33.3",
+ "clap 2.34.0",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -124,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block"
@@ -162,9 +232,15 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "calloop"
@@ -178,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cexpr"
@@ -205,9 +281,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
+checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
 dependencies = [
  "glob",
  "libc",
@@ -216,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -231,17 +307,32 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.15"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a35a599b11c089a7f49105658d089b8f2cf0882993c17daf6de15285c2c35d"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
  "indexmap",
+ "lazy_static",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -255,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.45"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
 dependencies = [
  "cc",
 ]
@@ -286,8 +377,8 @@ dependencies = [
  "bitflags",
  "block",
  "cocoa-foundation",
- "core-foundation 0.9.1",
- "core-graphics 0.22.2",
+ "core-foundation 0.9.3",
+ "core-graphics 0.22.3",
  "foreign-types",
  "libc",
  "objc",
@@ -301,7 +392,7 @@ checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 dependencies = [
  "bitflags",
  "block",
- "core-foundation 0.9.1",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -310,15 +401,51 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50aab2529019abfabfa93f1e6c41ef392f91fbf179b347a7e96abb524884a08"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
+ "once_cell",
  "terminal_size",
  "winapi",
+]
+
+[[package]]
+name = "console-api"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cb05777feccbb2642d4f2df44d0505601a2cd88ca517d8c913f263a5a8dc8b"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f21a16ee925aa9d2bad2e296beffd6c5b1bfaad50af509d305b8e7f23af20fb"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -333,11 +460,11 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
- "core-foundation-sys 0.8.2",
+ "core-foundation-sys 0.8.3",
  "libc",
 ]
 
@@ -349,9 +476,9 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "core-graphics"
@@ -367,12 +494,12 @@ dependencies = [
 
 [[package]]
 name = "core-graphics"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269f35f69b542b80e736a20a89a05215c0ce80c2c03c514abb2e318b78379d86"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.1",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -385,7 +512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.1",
+ "core-foundation 0.9.3",
  "foreign-types",
  "libc",
 ]
@@ -404,10 +531,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.2"
+name = "crc32fast"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -415,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -431,9 +577,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "darling"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -441,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
@@ -455,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
@@ -534,6 +680,31 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.10.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843c03199d0c0ca54bc1ea90ac0d507274c28abcc4f691ae8b4eaa375087c76a"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin",
 ]
 
 [[package]]
@@ -647,6 +818,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +841,25 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "h2"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "half"
@@ -671,6 +874,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31672b7011be2c4f7456c4ddbcb40e7e9a4a9fad8efe49a6ebaf5f307d0109c0"
+dependencies = [
+ "base64",
+ "byteorder",
+ "flate2",
+ "nom 7.1.1",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,18 +894,94 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "http"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
+name = "httparse"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
 
 [[package]]
 name = "ident_case"
@@ -699,9 +991,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -721,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -742,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jni-sys"
@@ -754,9 +1046,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -775,34 +1067,41 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.120"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "libloading"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi",
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.6"
+name = "linked-hash-map"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "lock_api"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -817,16 +1116,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
+name = "matchers"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
@@ -862,6 +1170,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,25 +1192,23 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba42135c6a5917b9db9cd7b293e5409e1c6b041e6f9825e92e55a894c63b6f8"
+checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
- "wasi",
- "winapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
 ]
 
 [[package]]
-name = "miow"
-version = "0.3.7"
+name = "nanorand"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "winapi",
+ "getrandom",
 ]
 
 [[package]]
@@ -908,15 +1226,15 @@ dependencies = [
 
 [[package]]
 name = "ndk-context"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5cc68637e21fe8f077f6a1c9e0b9ca495bb74895226b476310f613325884"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-glue"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c68f70683c5fc9a747a383744206cd371741b2f0b31781ab6770487ec572e2"
+checksum = "c71bee8ea72d685477e28bd004cfe1bf99c754d688cd78cad139eae4089484d4"
 dependencies = [
  "lazy_static",
  "libc",
@@ -971,21 +1289,21 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.0.1"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88034cfd6b4a0d54dd14f4a507eceee36c0b70e5a02236c4e4df571102be17f0"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
- "version_check",
+ "minimal-lexical",
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.3.6"
+name = "num-traits"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "winapi",
+ "autocfg",
 ]
 
 [[package]]
@@ -1000,19 +1318,18 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5adf0198d427ee515335639f275e806ca01acf9f07d7cf14bb36a10532a6169"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
 dependencies = [
- "derivative",
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1def5a3f69d4707d8a040b12785b98029a39e8c610ae685c7f6265669767482"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1047,18 +1364,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.28.3"
+version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "os_str_bytes"
@@ -1093,7 +1410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -1112,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1136,10 +1453,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.7"
+name = "pin-project"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -1149,49 +1486,136 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
-name = "pollster"
-version = "0.2.5"
+name = "ppv-lite86"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.0.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
  "toml",
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.36"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.9"
+name = "prost"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "bc03e116981ff7d8da8e5c220e374587b98d294af7ba7dd7fda761158f00086f"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+dependencies = [
+ "bytes",
+ "prost",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "raw-window-handle"
-version = "0.4.2"
+name = "rand"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba75eee94a9d5273a68c9e1e105d9cffe1ef700532325788389e5a83e2522b7"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b800beb9b6e7d2df1fe337c9e3d04e3af22a124460fb4c30fcc22c9117cefb41"
 dependencies = [
  "cty",
 ]
@@ -1205,19 +1629,23 @@ dependencies = [
  "async-trait",
  "backtrace",
  "bytemuck",
- "clap 3.1.15",
+ "clap 3.1.18",
+ "console-subscriber",
  "derivative",
  "dhat",
+ "flume",
  "futures",
  "glob",
  "indicatif",
  "itertools",
  "num_cpus",
  "owning_ref",
- "pollster",
+ "serde",
+ "serde_yaml",
  "shellwords",
  "shlex 1.1.0",
  "tiff-encoder",
+ "tokio",
  "v4l",
  "v4l2-sys-mit",
  "vulkano",
@@ -1228,21 +1656,30 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax",
 ]
 
@@ -1266,9 +1703,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "scoped-tls"
@@ -1284,18 +1721,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1304,13 +1741,25 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.71"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -1331,6 +1780,15 @@ checksum = "a36f3465fce5830d33a58846b9c924f510a1e92bac181834c13b38405efe983b"
 dependencies = [
  "cmake",
  "libc",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1366,10 +1824,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
-name = "slab"
-version = "0.4.2"
+name = "signal-hook-registry"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
@@ -1379,9 +1846,9 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1325f292209cee78d5035530932422a30aa4c8fda1a16593ac083c1de211e68a"
+checksum = "8a28f16a97fa0e8ce563b2774d1e732dd5d4025d2772c5dba0a41a0f90a29da3"
 dependencies = [
  "bitflags",
  "calloop",
@@ -1394,6 +1861,25 @@ dependencies = [
  "wayland-client",
  "wayland-cursor",
  "wayland-protocols",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -1416,9 +1902,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1426,19 +1912,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.2"
+name = "sync_wrapper"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "terminal_size"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
@@ -1461,18 +1953,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1486,6 +1978,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "tiff-encoder"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,25 +1996,240 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.7"
+name = "tokio"
+version = "1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
+dependencies = [
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "parking_lot 0.12.0",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "tracing",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.8"
+name = "tonic"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d342c6d58709c0a6d48d48dabbb62d4ef955cf5f0f3bbfd845838e7ae88dbae"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
+name = "tracing"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+dependencies = [
+ "cfg-if 1.0.0",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+dependencies = [
+ "lazy_static",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+dependencies = [
+ "lazy_static",
+ "matchers",
+ "regex",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "v4l"
@@ -1536,6 +2252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,9 +2265,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vk-parse"
@@ -1609,6 +2331,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,9 +2354,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -1626,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1641,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1651,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1664,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wayland-client"
@@ -1743,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1793,9 +2531,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.32.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -1806,33 +2544,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.32.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.32.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.32.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.32.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.32.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winit"
@@ -1842,8 +2580,8 @@ checksum = "9b43cc931d58b99461188607efd7acb2a093e65fc621f54cad78517a6063e73a"
 dependencies = [
  "bitflags",
  "cocoa 0.24.0",
- "core-foundation 0.9.1",
- "core-graphics 0.22.2",
+ "core-foundation 0.9.3",
+ "core-graphics 0.22.3",
  "core-video-sys",
  "dispatch",
  "instant",
@@ -1869,27 +2607,35 @@ dependencies = [
 
 [[package]]
 name = "x11-dl"
-version = "2.18.5"
+version = "2.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf981e3a5b3301209754218f962052d4d9ee97e478f4d26d4a6eced34c1fef8"
+checksum = "ea26926b4ce81a6f5d9d0f3a0bc401e5a37c6ae14a1bfaa8ff6099ca80038c59"
 dependencies = [
  "lazy_static",
  "libc",
- "maybe-uninit",
  "pkg-config",
 ]
 
 [[package]]
 name = "xcursor"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9a231574ae78801646617cefd13bfe94be907c0e4fa979cfd8b770aa3c5d08"
+checksum = "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7"
 dependencies = [
- "nom 6.0.1",
+ "nom 7.1.1",
 ]
 
 [[package]]
 name = "xml-rs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "ash"
@@ -58,9 +58,9 @@ checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -86,9 +86,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
 dependencies = [
  "addr2line",
  "cc",
@@ -142,18 +142,18 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "bytemuck"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e851ca7c24871e7336801608a4797d7376545b6928a10d32d75685687141ead"
+checksum = "cdead85bdec19c194affaeeb670c0e41fe23de31459efd1c174d049269cf02cc"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e215f8c2f9f79cb53c8335e687ffd07d5bfcb6fe5fc80723762d0be46e7cc54"
+checksum = "562e382481975bc61d11275ac5e62a19abd00b0547d99516a415336f183dcd0e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -231,17 +231,26 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.6"
+version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+checksum = "85a35a599b11c089a7f49105658d089b8f2cf0882993c17daf6de15285c2c35d"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_lex",
  "indexmap",
- "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -854,12 +863,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
@@ -1039,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "memchr",
 ]
@@ -1057,9 +1065,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "owning_ref"
@@ -1166,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -1200,7 +1205,7 @@ dependencies = [
  "async-trait",
  "backtrace",
  "bytemuck",
- "clap 3.1.6",
+ "clap 3.1.15",
  "derivative",
  "dhat",
  "futures",
@@ -1411,9 +1416,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Jaro <jarohabiger@googlemail.com>"]
 repository = "https://github.com/axiom-micro/recorder"
 readme = "README.md"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []
@@ -13,20 +13,20 @@ dhat-heap = ["dhat"]
 track-drop = ["backtrace"]
 
 [dependencies]
-clap = "3.1.6"
+clap = "3.1.15"
 indicatif = "0.16.2"
 tiff-encoder = "0.3.2"
 glob = "0.3.0"
-anyhow = "1.0.56"
+anyhow = "1.0.57"
 itertools = "0.10.3"
-bytemuck = "1.8.0"
+bytemuck = "1.9.1"
 vulkano = "0.29.0"
 vulkano-shaders = "0.29.0"
 vulkano-win = "0.29.0"
 owning_ref = "0.4.1"
 shlex = "1.1.0"
 winit = "0.26.1"
-async-trait = "0.1.52"
+async-trait = "0.1.53"
 futures = "0.3.21"
 async-task = "4.2.0"
 derivative = "2.2.0"
@@ -34,7 +34,7 @@ pollster = "0.2.5"
 shellwords = "1.1.0"
 num_cpus = "1.13.1"
 dhat = { version = "0.3.0", optional = true }
-backtrace = { version = "0.3.64", optional = true }
+backtrace = { version = "0.3.65", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 v4l = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ dhat-heap = ["dhat"]
 track-drop = ["backtrace"]
 
 [dependencies]
-clap = "3.1.15"
+clap = { version = "3.1.18", features = ["default", "derive"] }
 indicatif = "0.16.2"
 tiff-encoder = "0.3.2"
 glob = "0.3.0"
@@ -30,11 +30,15 @@ async-trait = "0.1.53"
 futures = "0.3.21"
 async-task = "4.2.0"
 derivative = "2.2.0"
-pollster = "0.2.5"
 shellwords = "1.1.0"
 num_cpus = "1.13.1"
 dhat = { version = "0.3.0", optional = true }
 backtrace = { version = "0.3.65", optional = true }
+serde = { version = "1.0.137", features = ["std", "derive"] }
+serde_yaml = "0.8.24"
+flume = "0.10.12"
+tokio = { version = "1.18.2", features = ["full"] }
+console-subscriber = "0.1.5"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 v4l = "0.12.1"

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,44 @@
+dir_input:
+  type: RawDirectoryReader
+  internal-loop: true
+  cache-frames: true
+  # file-pattern: test/24fps-bubbles/*
+  # width: 1920
+  # height: 1080
+  # rgb: true
+  file-pattern: test/*/tl-*.raw12
+  width: 4096
+  height: 3072
+
+# dual_frame_decoder:
+#   type: DualFrameRawDecoder
+#   input: <dir_input
+
+bench_sink:
+  type: BenchmarkSink
+  input: <bitdepth_conv
+    #
+    #     #bench_sink2:
+    #     #  type: BenchmarkSink
+    #     #  input: <dir_input
+    #     #
+bitdepth_conv:
+  type: BitDepthConverter
+    #  input: <dual_frame_decoder
+  input: <dir_input
+
+debayer:
+  type: Debayer
+  input: <bitdepth_conv
+
+display:
+  type: Display
+  input: <debayer
+  mailbox: true
+  live: true
+
+display2:
+  type: Display
+  input: <debayer
+  mailbox: true
+  live: true

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,16 +1,16 @@
 use anyhow::{anyhow, Context, Result};
-use clap::{Arg, Command};
+use clap::{Arg, Parser};
 
 use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
 use recorder::{
     nodes::list_available_nodes,
     pipeline_processing::{
-        node::NodeID,
         parametrizable::{
             ParameterType,
             ParameterTypeDescriptor,
             ParameterTypeDescriptor::{Mandatory, Optional},
+            ParameterValue,
             ParameterizableDescriptor,
             Parameters,
         },
@@ -18,17 +18,102 @@ use recorder::{
         processing_graph::{ProcessingGraph, ProcessingNodeConfig},
     },
 };
+use serde::{Deserialize, Deserializer};
 use std::{
     collections::HashMap,
     iter::once,
     sync::{Arc, Mutex},
 };
 
+#[derive(Debug, Clone)]
+enum NodeParam {
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    String(String),
+    NodeInput(String),
+}
+
+impl<'de> Deserialize<'de> for NodeParam {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize, Debug)]
+        #[serde(untagged)]
+        enum NodeParamSimple {
+            Int(i64),
+            Float(f64),
+            Bool(bool),
+            String(String),
+        }
+
+        let param = NodeParamSimple::deserialize(deserializer)?;
+        Ok(match param {
+            NodeParamSimple::Float(f) => NodeParam::Float(f),
+            NodeParamSimple::Int(i) => NodeParam::Int(i),
+            NodeParamSimple::String(s) => {
+                if let Some(s) = s.strip_prefix('<') {
+                    NodeParam::NodeInput(s.to_owned())
+                } else {
+                    NodeParam::String(s)
+                }
+            }
+            NodeParamSimple::Bool(b) => NodeParam::Bool(b),
+        })
+    }
+}
+
+#[derive(Deserialize, Debug)]
+struct NodeConfig {
+    #[serde(rename = "type")]
+    ty: String,
+    #[serde(flatten)]
+    parameters: HashMap<String, NodeParam>,
+}
+
+impl From<NodeConfig> for ProcessingNodeConfig<String> {
+    fn from(node_config: NodeConfig) -> Self {
+        Self {
+            name: node_config.ty,
+            parameters: Parameters::new(
+                node_config
+                    .parameters
+                    .clone()
+                    .into_iter()
+                    .filter_map(|(name, param)| match param {
+                        NodeParam::Float(f) => Some((name, ParameterValue::FloatRange(f))),
+                        NodeParam::Int(i) => Some((name, ParameterValue::IntRange(i))),
+                        NodeParam::String(s) => Some((name, ParameterValue::StringParameter(s))),
+                        NodeParam::Bool(b) => Some((name, ParameterValue::BoolParameter(b))),
+                        NodeParam::NodeInput(_) => None,
+                    })
+                    .collect(),
+            ),
+            inputs: node_config
+                .parameters
+                .into_iter()
+                .filter_map(|(name, param)| match param {
+                    NodeParam::NodeInput(i) => Some((name, i)),
+                    _ => None,
+                })
+                .collect(),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+struct PipelineConfig {
+    #[serde(flatten)]
+    nodes: HashMap<String, NodeConfig>,
+}
+
 #[cfg(feature = "dhat-heap")]
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
 fn main() {
+    console_subscriber::init();
     #[cfg(feature = "dhat-heap")]
     let _profiler = dhat::Profiler::new_heap();
 
@@ -41,60 +126,121 @@ fn main() {
     }
 }
 
+#[derive(clap::Subcommand, Debug)]
+enum Command {
+    /// specify the processing pipeline directly on the cli
+    #[clap(after_help = leaked_thing(&format!("NODES:\n{}", nodes_usages_string())).as_str())]
+    FromCli {
+        #[clap(
+            help = "example: <Node1> --source-arg ! <Node2> --sink-arg",
+            allow_hyphen_values(true)
+        )]
+        pipeline: Vec<String>,
+    },
+    /// specify the pipeline configuration from a (yaml) file
+    FromFile {
+        /// path to the configuration file
+        file: std::path::PathBuf,
+    },
+}
+
+/// Raw Image / Video Converter
+#[derive(Parser, Debug)]
+#[clap(
+    version,
+    about,
+    long_about = "convert raw footage from AXIOM cameras into other formats.",
+    author
+)]
+struct Args {
+    #[clap(subcommand)]
+    command: Command,
+    /// show a progress bar
+    #[clap(long, short)]
+    show_progress: bool,
+}
+
 // used to have the convenience of ? for error handling
 fn work() -> Result<()> {
-    let main_app_arguments = Command::new("Raw Image / Video Converter")
+    let args = Args::parse();
+    /*
+    let main_app_arguments = clap::Command::new("Raw Image / Video Converter")
         .about("convert raw footage from AXIOM cameras into other formats.")
-        .trailing_var_arg(true)
-        .arg(
-            Arg::new("pipeline")
-                .required(true)
-                .multiple_values(true)
-                .help("example: <Node1> --source-arg ! <Node2> --sink-arg"),
-        )
-        .after_help(format!("NODES:\n{}", nodes_usages_string()).as_str())
+        .subcommand(clap::Command::new("from-cli")
+            .about("specify the pipeline directly on the cli")
+            .trailing_var_arg(true)
+            .arg(
+                Arg::new("pipeline")
+                    .required(true)
+                    .multiple_values(true)
+                    .help("example: <Node1> --source-arg ! <Node2> --sink-arg"),
+            )
+            .after_help(format!("NODES:\n{}", nodes_usages_string()).as_str()))
+        .subcommand(clap::Command::new("from-file")
+            .about("specify the pipeline configuration from a (yaml) file")
+            .arg(Arg::new("file")
+                 .number_of_values(1)
+                 .required(true)
+                 .help("config.yaml")))
         .get_matches();
+        */
 
-    let pipeline_raw: Vec<_> = main_app_arguments.values_of("pipeline").unwrap().collect();
-    let pipeline_split = if pipeline_raw.len() == 1 {
-        shellwords::split(pipeline_raw[0])?
-    } else {
-        pipeline_raw.iter().map(|f| f.to_string()).collect()
-    };
-    let node_commandlines = pipeline_split.split(|element| element == "!").collect::<Vec<_>>();
 
     let processing_context = ProcessingContext::default();
 
-    let mut processing_graph = ProcessingGraph::new();
-    let mut last_element = None;
+    let processing_graph = match args.command {
+        Command::FromCli { pipeline } => {
+            let node_commandlines = pipeline.split(|element| element == "!").collect::<Vec<_>>();
+            let mut processing_graph = ProcessingGraph::new();
 
-    for node_cmd in node_commandlines {
-        last_element = Some(processing_graph.add(processing_node_from_commandline(
-            node_cmd,
-            last_element,
-            &processing_context,
-        )?));
-    }
+            for (i, node_cmd) in node_commandlines.iter().enumerate() {
+                processing_graph.add(
+                    i,
+                    processing_node_from_commandline(
+                        node_cmd,
+                        if i > 0 { Some(i - 1) } else { None },
+                        &processing_context,
+                    )?,
+                )?;
+            }
 
-    let progressbar: Arc<Mutex<Option<ProgressBar>>> = Default::default();
-    let processing_graph = processing_graph.build(&processing_context)?;
-
-    processing_graph.run(&processing_context, move |progress| {
-        let mut lock = progressbar.lock().unwrap();
-        if lock.is_none() {
-            let progressbar = if let Some(total_frames) = progress.total_frames {
-                let bar = ProgressBar::new(total_frames);
-                bar.set_style(ProgressStyle::default_bar()
-                    .template("{wide_bar} | {pos}/{len} frames | elapsed: {elapsed_precise} | remaining: {eta} | {msg} ")
-                    .progress_chars("#>-"));
-                bar
-            } else {
-                ProgressBar::new_spinner()
-            };
-            *lock = Some(progressbar)
+            processing_graph.build(&processing_context)?
         }
-        lock.as_ref().unwrap().set_position(progress.latest_frame);
-    })?;
+        Command::FromFile { file } => {
+            let config: PipelineConfig = serde_yaml::from_str(&std::fs::read_to_string(file)?)?;
+
+            let mut processing_graph = ProcessingGraph::new();
+
+            for (name, node) in config.nodes {
+                processing_graph.add(name, node.into())?;
+            }
+            processing_graph.build(&processing_context)?
+        }
+    };
+
+
+    if args.show_progress {
+        let progressbar: Arc<Mutex<Option<ProgressBar>>> = Default::default();
+
+        processing_graph.run(processing_context, move |progress| {
+            let mut lock = progressbar.lock().unwrap();
+            if lock.is_none() {
+                let progressbar = if let Some(total_frames) = progress.total_frames {
+                    let bar = ProgressBar::new(total_frames);
+                    bar.set_style(ProgressStyle::default_bar()
+                        .template("{wide_bar} | {pos}/{len} frames | elapsed: {elapsed_precise} | remaining: {eta} | {msg} ")
+                        .progress_chars("#>-"));
+                    bar
+                } else {
+                    ProgressBar::new_spinner()
+                };
+                *lock = Some(progressbar)
+            }
+            lock.as_ref().unwrap().set_position(progress.latest_frame);
+        })?;
+    } else {
+        processing_graph.run(processing_context, |_| {})?;
+    }
 
     Ok(())
 }
@@ -117,9 +263,9 @@ fn nodes_usages_string() -> String {
 }
 fn processing_node_from_commandline(
     commandline: &[String],
-    input: Option<NodeID>,
+    input: Option<usize>,
     _context: &ProcessingContext,
-) -> Result<ProcessingNodeConfig> {
+) -> Result<ProcessingNodeConfig<usize>> {
     let name = &commandline[0];
 
     let available_nodes: HashMap<String, ParameterizableDescriptor> = list_available_nodes();
@@ -163,24 +309,11 @@ fn processing_node_from_commandline(
         Parameters::new(parameters),
         input,
     ))
-
-    /*
-    if let Some(last_node) = last_node {
-        if let Node::Node(last_node) = last_node {
-            parameters.insert("input".to_string(), ParameterValue::NodeInput(last_node));
-        } else {
-            return Err(anyhow!("cant use sink as non last element!"));
-        }
-    }
-
-    create_node_from_name(name, &Parameters(parameters), context)
-        .with_context(|| format!("Error while creating Node {}", name))
-        */
 }
 
 fn leaked_thing<T: Clone>(s: &T) -> &'static T { Box::leak(Box::new(s.clone())) }
 
-fn clap_app_from_node_name(name: &str) -> Result<Command<'static>> {
+fn clap_app_from_node_name(name: &str) -> Result<clap::Command<'static>> {
     let available_nodes: HashMap<String, ParameterizableDescriptor> = list_available_nodes();
     let node_descriptor: &ParameterizableDescriptor =
         available_nodes.get(name).ok_or_else(|| {
@@ -191,7 +324,7 @@ fn clap_app_from_node_name(name: &str) -> Result<Command<'static>> {
             )
         })?;
 
-    let mut app = Command::new(node_descriptor.name.clone());
+    let mut app = clap::Command::new(node_descriptor.name.clone());
     if let Some(description) = node_descriptor.description.clone() {
         app = app.about(leaked_thing(&description).as_str());
     }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -44,6 +44,7 @@ macro_rules! generate_dynamic_node_creation_functions {
                 $(#[$m])?
                 if name == <$x>::get_name() {
                     let parameters = parameters.add_inputs(node_id, inputs)?;
+                    let parameters = parameters.add_defaults(<$x>::describe_parameters());
                     return Ok(<$x>::from_parameters(parameters, is_input_to, &context)?.into_processing_element())
                 };
             )+

--- a/src/nodes_cpu/bitdepth_convert.rs
+++ b/src/nodes_cpu/bitdepth_convert.rs
@@ -1,20 +1,21 @@
 use crate::pipeline_processing::{
+    node::InputProcessingNode,
     parametrizable::{Parameterizable, Parameters, ParametersDescriptor},
     payload::Payload,
 };
 use anyhow::{Context, Result};
-use std::sync::Arc;
+
 
 use crate::pipeline_processing::{
     frame::{Frame, FrameInterpretation, Raw},
-    node::{Caps, ProcessingNode},
+    node::{Caps, NodeID, ProcessingNode},
     parametrizable::{ParameterType, ParameterTypeDescriptor},
     processing_context::ProcessingContext,
 };
 use async_trait::async_trait;
 
 pub struct BitDepthConverter {
-    input: Arc<dyn ProcessingNode + Send + Sync>,
+    input: InputProcessingNode,
 }
 impl Parameterizable for BitDepthConverter {
     fn describe_parameters() -> ParametersDescriptor {
@@ -22,14 +23,23 @@ impl Parameterizable for BitDepthConverter {
             .with("input", ParameterTypeDescriptor::Mandatory(ParameterType::NodeInput))
     }
 
-    fn from_parameters(parameters: &Parameters, _context: &ProcessingContext) -> Result<Self> {
+    fn from_parameters(
+        mut parameters: Parameters,
+        _is_input_to: &[NodeID],
+        _context: &ProcessingContext,
+    ) -> Result<Self> {
         Ok(Self { input: parameters.get("input")? })
     }
 }
 
 #[async_trait]
 impl ProcessingNode for BitDepthConverter {
-    async fn pull(&self, frame_number: u64, context: &ProcessingContext) -> Result<Payload> {
+    async fn pull(
+        &self,
+        frame_number: u64,
+        _puller_id: NodeID,
+        context: &ProcessingContext,
+    ) -> Result<Payload> {
         let input = self.input.pull(frame_number, context).await?;
         let frame = context.ensure_cpu_buffer::<Raw>(&input).context("Wrong input format")?;
         let interp = Raw { bit_depth: 8, ..frame.interp };

--- a/src/nodes_gpu/debayer.rs
+++ b/src/nodes_gpu/debayer.rs
@@ -2,7 +2,7 @@ use crate::pipeline_processing::{
     buffers::GpuBuffer,
     frame::{Frame, FrameInterpretation, Raw, Rgb},
     gpu_util::ensure_gpu_buffer,
-    node::{Caps, ProcessingNode},
+    node::{Caps, InputProcessingNode, NodeID, ProcessingNode},
     parametrizable::{
         ParameterType,
         ParameterTypeDescriptor,
@@ -39,7 +39,7 @@ pub struct Debayer {
     device: Arc<Device>,
     pipeline: Arc<ComputePipeline>,
     queue: Arc<Queue>,
-    input: Arc<dyn ProcessingNode + Send + Sync>,
+    input: InputProcessingNode,
 }
 
 impl Parameterizable for Debayer {
@@ -47,7 +47,11 @@ impl Parameterizable for Debayer {
         ParametersDescriptor::default()
             .with("input", ParameterTypeDescriptor::Mandatory(ParameterType::NodeInput))
     }
-    fn from_parameters(parameters: &Parameters, context: &ProcessingContext) -> Result<Self>
+    fn from_parameters(
+        mut parameters: Parameters,
+        _is_input_to: &[NodeID],
+        context: &ProcessingContext,
+    ) -> Result<Self>
     where
         Self: Sized,
     {
@@ -70,7 +74,12 @@ impl Parameterizable for Debayer {
 
 #[async_trait]
 impl ProcessingNode for Debayer {
-    async fn pull(&self, frame_number: u64, context: &ProcessingContext) -> Result<Payload> {
+    async fn pull(
+        &self,
+        frame_number: u64,
+        _puller_id: NodeID,
+        context: &ProcessingContext,
+    ) -> Result<Payload> {
         let input = self.input.pull(frame_number, context).await?;
 
         let (frame, fut) =

--- a/src/nodes_io/reader_raw.rs
+++ b/src/nodes_io/reader_raw.rs
@@ -166,8 +166,8 @@ impl ProcessingNode for RawDirectoryReader {
         }
 
         if self.cache_frames {
-            if let Some(cached) = self.cache.lock().unwrap()[frame_number as usize].clone() {
-                return Ok(cached);
+            if let Some(cached) = &self.cache.lock().unwrap()[frame_number as usize] {
+                return Ok(cached.clone());
             }
         }
 
@@ -184,7 +184,9 @@ impl ProcessingNode for RawDirectoryReader {
             FrameInterpretations::Rgba(interp) => Payload::from(Frame { storage: buffer, interp }),
         };
 
-        self.cache.lock().unwrap()[frame_number as usize] = Some(payload.clone());
+        if self.cache_frames {
+            self.cache.lock().unwrap()[frame_number as usize] = Some(payload.clone());
+        }
         Ok(payload)
     }
 

--- a/src/nodes_io/reader_raw.rs
+++ b/src/nodes_io/reader_raw.rs
@@ -1,6 +1,6 @@
 use crate::pipeline_processing::{
     frame::{Frame, FrameInterpretation, FrameInterpretations},
-    node::{Caps, ProcessingNode},
+    node::{Caps, NodeID, ProcessingNode},
     parametrizable::{
         ParameterType::{BoolParameter, StringParameter},
         ParameterTypeDescriptor::{Mandatory, Optional},
@@ -40,7 +40,11 @@ impl Parameterizable for RawBlobReader {
             .with("file", Mandatory(StringParameter))
             .with("cache-frames", Optional(BoolParameter, ParameterValue::BoolParameter(false)))
     }
-    fn from_parameters(options: &Parameters, _context: &ProcessingContext) -> anyhow::Result<Self>
+    fn from_parameters(
+        mut options: Parameters,
+        _is_input_to: &[NodeID],
+        _context: &ProcessingContext,
+    ) -> anyhow::Result<Self>
     where
         Self: Sized,
     {
@@ -60,7 +64,12 @@ impl Parameterizable for RawBlobReader {
 }
 #[async_trait]
 impl ProcessingNode for RawBlobReader {
-    async fn pull(&self, frame_number: u64, context: &ProcessingContext) -> Result<Payload> {
+    async fn pull(
+        &self,
+        frame_number: u64,
+        _puller_id: NodeID,
+        context: &ProcessingContext,
+    ) -> Result<Payload> {
         if frame_number >= self.frame_count as u64 {
             return Err(anyhow!(
                 "frame {} was requested but this stream only has a length of {}",
@@ -116,7 +125,11 @@ impl Parameterizable for RawDirectoryReader {
             .with("cache-frames", Optional(BoolParameter, ParameterValue::BoolParameter(false)))
             .with("internal-loop", Optional(BoolParameter, ParameterValue::BoolParameter(false)))
     }
-    fn from_parameters(options: &Parameters, _context: &ProcessingContext) -> anyhow::Result<Self>
+    fn from_parameters(
+        mut options: Parameters,
+        _is_input_to: &[NodeID],
+        _context: &ProcessingContext,
+    ) -> anyhow::Result<Self>
     where
         Self: Sized,
     {
@@ -135,7 +148,12 @@ impl Parameterizable for RawDirectoryReader {
 
 #[async_trait]
 impl ProcessingNode for RawDirectoryReader {
-    async fn pull(&self, mut frame_number: u64, context: &ProcessingContext) -> Result<Payload> {
+    async fn pull(
+        &self,
+        mut frame_number: u64,
+        _puller_id: NodeID,
+        context: &ProcessingContext,
+    ) -> Result<Payload> {
         if self.internal_loop {
             frame_number %= self.files.len() as u64;
         }

--- a/src/nodes_io/reader_tcp.rs
+++ b/src/nodes_io/reader_tcp.rs
@@ -1,7 +1,7 @@
 use crate::{
     pipeline_processing::{
         frame::{Frame, FrameInterpretation, FrameInterpretations},
-        node::{Caps, ProcessingNode},
+        node::{Caps, NodeID, ProcessingNode},
         parametrizable::{
             ParameterType::StringParameter,
             ParameterTypeDescriptor::Mandatory,
@@ -30,7 +30,11 @@ impl Parameterizable for TcpReader {
             .with_interpretation()
     }
 
-    fn from_parameters(parameters: &Parameters, _context: &ProcessingContext) -> Result<Self>
+    fn from_parameters(
+        mut parameters: Parameters,
+        _is_input_to: &[NodeID],
+        _context: &ProcessingContext,
+    ) -> Result<Self>
     where
         Self: Sized,
     {
@@ -44,7 +48,12 @@ impl Parameterizable for TcpReader {
 
 #[async_trait]
 impl ProcessingNode for TcpReader {
-    async fn pull(&self, frame_number: u64, context: &ProcessingContext) -> Result<Payload> {
+    async fn pull(
+        &self,
+        frame_number: u64,
+        _puller_id: NodeID,
+        context: &ProcessingContext,
+    ) -> Result<Payload> {
         self.notifier.wait(move |x| *x >= frame_number).await;
 
         let mut buffer = unsafe { context.get_uninit_cpu_buffer(self.interp.required_bytes()) };

--- a/src/pipeline_processing/mod.rs
+++ b/src/pipeline_processing/mod.rs
@@ -6,4 +6,5 @@ pub mod parametrizable;
 pub mod payload;
 pub mod prioritized_executor;
 pub mod processing_context;
+pub mod processing_graph;
 pub mod puller;

--- a/src/pipeline_processing/node.rs
+++ b/src/pipeline_processing/node.rs
@@ -14,8 +14,45 @@ pub struct Caps {
 
 #[async_trait]
 pub trait ProcessingNode {
-    async fn pull(&self, frame_number: u64, context: &ProcessingContext) -> Result<Payload>;
+    async fn pull(
+        &self,
+        frame_number: u64,
+        requester: NodeID,
+        context: &ProcessingContext,
+    ) -> Result<Payload>;
     fn get_caps(&self) -> Caps;
+}
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub struct NodeID(u16);
+
+pub struct InputProcessingNode {
+    node: Arc<dyn ProcessingNode + Send + Sync>,
+    puller_id: NodeID,
+}
+
+impl From<usize> for NodeID {
+    fn from(value: usize) -> Self { NodeID(value as _) }
+}
+
+impl From<NodeID> for usize {
+    fn from(value: NodeID) -> Self { value.0 as _ }
+}
+
+impl InputProcessingNode {
+    pub(crate) fn new(puller_id: NodeID, node: Arc<dyn ProcessingNode + Send + Sync>) -> Self {
+        Self { node, puller_id }
+    }
+
+    pub async fn pull(&self, frame_number: u64, context: &ProcessingContext) -> Result<Payload> {
+        self.node.pull(frame_number, self.puller_id, context).await
+    }
+
+    fn copy_with(&self, puller_id: NodeID) -> Self { Self { node: self.node.clone(), puller_id } }
+
+    pub(crate) fn clone_for_same_puller(&self) -> Self { self.copy_with(self.puller_id) }
+
+    pub fn get_caps(&self) -> Caps { self.node.get_caps() }
 }
 
 #[async_trait]
@@ -26,6 +63,7 @@ pub trait SinkNode {
         progress_callback: Arc<dyn Fn(ProgressUpdate) + Send + Sync>,
     ) -> Result<()>;
 }
+
 #[derive(Copy, Clone, Debug)]
 pub struct ProgressUpdate {
     pub latest_frame: u64,
@@ -33,9 +71,28 @@ pub struct ProgressUpdate {
 }
 
 
+#[derive(Clone)]
 pub enum Node {
     Node(Arc<dyn ProcessingNode + Send + Sync + 'static>),
     Sink(Arc<dyn SinkNode + Send + Sync + 'static>),
+}
+impl Node {
+    pub fn is_sink(&self) -> bool { matches!(self, Node::Sink(_)) }
+    pub fn assert_input_node(&self) -> Result<Arc<dyn ProcessingNode + Send + Sync + 'static>> {
+        match self {
+            Self::Node(node) => Ok(node.clone()),
+            Self::Sink(_sink) => Err(anyhow::anyhow!("wanted to get a input node, was a sink")),
+        }
+    }
+
+    pub fn assert_sink(&self) -> Result<Arc<dyn SinkNode + Send + Sync + 'static>> {
+        match self {
+            Self::Sink(sink) => Ok(sink.clone()),
+            Self::Node(_node) => {
+                Err(anyhow::anyhow!("wanted to get a sink node, was a normal node"))
+            }
+        }
+    }
 }
 impl Debug for Node {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/src/pipeline_processing/parametrizable.rs
+++ b/src/pipeline_processing/parametrizable.rs
@@ -134,7 +134,11 @@ impl Parameters {
         parameter_value.try_into()
     }
 
-    pub fn add_inputs(mut self, puller_id: NodeID, inputs: HashMap<String, Node>) -> Result<Self> {
+    pub(crate) fn add_inputs(
+        mut self,
+        puller_id: NodeID,
+        inputs: HashMap<String, Node>,
+    ) -> Result<Self> {
         for (name, node) in inputs {
             self.values.insert(
                 name.clone(),
@@ -148,6 +152,16 @@ impl Parameters {
         }
 
         Ok(self)
+    }
+
+    pub(crate) fn add_defaults(mut self, description: ParametersDescriptor) -> Self {
+        for (name, value) in description.0 {
+            if let Optional(_, value) = value {
+                self.values.entry(name).or_insert(value);
+            }
+        }
+
+        self
     }
 
     pub fn get_interpretation(&mut self) -> Result<FrameInterpretations> {

--- a/src/pipeline_processing/payload.rs
+++ b/src/pipeline_processing/payload.rs
@@ -7,16 +7,16 @@ use std::{
 #[derive(Clone, Debug)]
 pub struct Payload {
     data: Arc<dyn Any + Send + Sync>,
-    pub type_name: String,
+    pub type_name: &'static str,
 }
 
 impl Payload {
     pub fn empty() -> Self { Payload::from(()) }
     pub fn from<T: Send + Sync + 'static>(payload: T) -> Self {
-        Payload { data: Arc::new(payload), type_name: type_name::<T>().to_string() }
+        Payload { data: Arc::new(payload), type_name: type_name::<T>() }
     }
     pub fn from_arc<T: Send + Sync + 'static>(payload: Arc<T>) -> Self {
-        Payload { data: payload, type_name: type_name::<T>().to_string() }
+        Payload { data: payload, type_name: type_name::<T>() }
     }
     pub fn downcast<T: Send + Sync + 'static>(&self) -> anyhow::Result<Arc<T>> {
         let downcast_result = self.data.clone().downcast::<T>();

--- a/src/pipeline_processing/processing_context.rs
+++ b/src/pipeline_processing/processing_context.rs
@@ -62,7 +62,10 @@ pub struct ProcessingContext {
 }
 impl Default for ProcessingContext {
     fn default() -> Self {
-        let threads = std::env::var("RECORDER_NUM_THREADS").map_err(|_| ()).and_then(|v| v.parse::<usize>().map_err(|_| ())).unwrap_or_else(|_| num_cpus::get());
+        let threads = std::env::var("RECORDER_NUM_THREADS")
+            .map_err(|_| ())
+            .and_then(|v| v.parse::<usize>().map_err(|_| ()))
+            .unwrap_or_else(|_| num_cpus::get());
         println!("using {threads} threads");
         let vk_device = Instance::new(InstanceCreateInfo {
             enabled_extensions: vulkano_win::required_extensions(),

--- a/src/pipeline_processing/processing_graph.rs
+++ b/src/pipeline_processing/processing_graph.rs
@@ -1,5 +1,9 @@
 use anyhow::Result;
-use std::collections::{HashMap, HashSet};
+use futures::StreamExt;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use crate::{
     nodes::create_node_from_name,
@@ -10,13 +14,18 @@ use crate::{
     },
 };
 
-pub struct ProcessingNodeConfig {
-    name: String,
-    parameters: Parameters,
-    inputs: HashMap<String, usize>,
+#[derive(Debug)]
+pub struct ProcessingNodeConfig<IdTy> {
+    pub name: String,
+    pub parameters: Parameters,
+    pub inputs: HashMap<String, IdTy>,
 }
-impl ProcessingNodeConfig {
-    pub fn single_input_node(name: String, parameters: Parameters, input: Option<NodeID>) -> Self {
+impl<IdTy> ProcessingNodeConfig<IdTy> {
+    pub fn single_input_node<T: Into<IdTy>>(
+        name: String,
+        parameters: Parameters,
+        input: Option<T>,
+    ) -> Self {
         ProcessingNodeConfig {
             inputs: ["input".to_owned()].into_iter().zip(input.map(|v| v.into())).collect(),
             parameters,
@@ -25,76 +34,103 @@ impl ProcessingNodeConfig {
     }
 }
 
-#[derive(Default)]
-pub struct ProcessingGraph {
-    nodes: Vec<Option<ProcessingNodeConfig>>,
+pub struct ProcessingGraph<IdTy> {
+    nodes: HashMap<IdTy, Option<ProcessingNodeConfig<IdTy>>>,
 }
 
-impl ProcessingGraph {
+impl<IdTy> Default for ProcessingGraph<IdTy> {
+    fn default() -> Self { Self { nodes: HashMap::new() } }
+}
+
+impl<IdTy> ProcessingGraph<IdTy>
+where
+    IdTy: std::cmp::Eq + std::hash::Hash + std::fmt::Debug + Clone,
+{
     pub fn new() -> Self { Default::default() }
 
-    pub fn add(&mut self, config: ProcessingNodeConfig) -> NodeID {
+    pub fn add(&mut self, name: IdTy, config: ProcessingNodeConfig<IdTy>) -> Result<NodeID> {
         let idx = self.nodes.len();
-        self.nodes.push(Some(config));
-        idx.into()
+        match self.nodes.entry(name.clone()) {
+            std::collections::hash_map::Entry::Occupied(e) => {
+                let e = e.get();
+                Err(anyhow::anyhow!(
+                    "tried to add node {config:?} with name {name:?}, but it already exists: {e:?}"
+                ))
+            }
+            std::collections::hash_map::Entry::Vacant(v) => {
+                v.insert(Some(config));
+                Ok(idx.into())
+            }
+        }
     }
 
     pub fn build(mut self, ctx: &ProcessingContext) -> Result<BuiltProcessingGraph> {
         if self.nodes.is_empty() {
             Ok(BuiltProcessingGraph { nodes: HashMap::new(), sinks: vec![] })
         } else {
+            let mut id_to_nodeid = HashMap::<IdTy, NodeID>::new();
             let mut is_input_to = HashMap::<_, Vec<_>>::new();
 
-            for (idx, node) in self.nodes.iter().enumerate() {
+            for (idx, id) in self.nodes.keys().enumerate() {
+                id_to_nodeid.insert(id.clone(), idx.into());
+            }
+
+            for (id, node) in self.nodes.iter() {
+                let idx = id_to_nodeid[id];
                 for input in node.as_ref().unwrap().inputs.values() {
-                    is_input_to.entry(*input).or_default().push(idx.into());
+                    is_input_to.entry(id_to_nodeid[input]).or_default().push(idx);
                 }
             }
 
 
-            let mut built_nodes = HashMap::<_, Node>::new();
-            let mut avail: HashSet<_> = (1..self.nodes.len()).collect();
-            let mut queue = vec![0];
+            let mut built_nodes = HashMap::<NodeID, Node>::new();
+            let mut avail: HashSet<IdTy> = id_to_nodeid.keys().cloned().collect();
+            let mut queue = vec![];
+            queue.push({
+                let v = avail.iter().cloned().next().unwrap();
+                avail.take(&v).unwrap()
+            });
             let mut sinks = vec![];
 
             while !queue.is_empty() {
-                let idx = *queue.last().unwrap();
+                let id = queue.last().unwrap().clone();
+                let idx = id_to_nodeid[&id];
                 let mut missing = vec![];
                 let mut finished = HashMap::new();
 
-                let node = std::mem::take(&mut self.nodes[idx]).unwrap();
+                let node = self.nodes.remove(&id).unwrap().unwrap();
 
                 for (name, input_id) in &node.inputs {
-                    if let Some(node) = built_nodes.get(&(*input_id).into()) {
+                    if let Some(node) = built_nodes.get(&id_to_nodeid[input_id]) {
                         finished.insert(name.clone(), node.clone());
                     } else {
-                        missing.push(*input_id)
+                        missing.push(input_id.clone())
                     }
                 }
 
                 if !missing.is_empty() {
                     queue.append(&mut missing);
-                    self.nodes[idx] = Some(node);
+                    self.nodes.insert(id, Some(node));
                 } else {
                     let built_node = create_node_from_name(
                         &node.name,
-                        idx.into(),
+                        idx,
                         node.parameters,
                         finished,
                         is_input_to.entry(idx).or_default(),
                         ctx,
                     )?;
                     if built_node.is_sink() {
-                        sinks.push(idx.into());
+                        sinks.push(idx);
                     }
-                    built_nodes.insert(idx.into(), built_node);
+                    built_nodes.insert(idx, built_node);
 
 
-                    avail.remove(&idx);
+                    avail.remove(&id);
                     queue.pop().unwrap();
 
                     if queue.is_empty() && !avail.is_empty() {
-                        queue.push(*avail.iter().next().unwrap())
+                        queue.push(avail.iter().next().unwrap().clone())
                     }
                 }
             }
@@ -112,19 +148,42 @@ pub struct BuiltProcessingGraph {
 impl BuiltProcessingGraph {
     pub fn run<FUNC: Fn(ProgressUpdate) + Send + Sync + Clone + 'static>(
         &self,
-        ctx: &ProcessingContext,
+        ctx: ProcessingContext,
         progress_update_cb: FUNC,
     ) -> Result<()> {
+        dbg!(&self.sinks);
+        let ctx = Arc::new(ctx);
         if self.sinks.is_empty() {
             Err(anyhow::anyhow!("processing graph should contain atleast one sink"))
         } else {
-            pollster::block_on(futures::future::try_join_all(self.sinks.iter().map(|id| async {
-                let sink = self.nodes.get(id).unwrap().assert_sink()?;
-                anyhow::Result::Ok(
-                    sink.run(ctx, std::sync::Arc::new(progress_update_cb.clone())).await?,
+            let res = ctx.block_on(async {
+                anyhow::Result::<_, anyhow::Error>::Ok(
+                    self.sinks
+                        .iter()
+                        .cloned()
+                        .map(|id| {
+                            let progress_update_cb = progress_update_cb.clone();
+                            let ctx = ctx.clone();
+                            let sink = self.nodes.get(&id).unwrap().assert_sink()?;
+                            Ok(async move {
+                                anyhow::Result::<_, anyhow::Error>::Ok(
+                                    sink.run(&*ctx, std::sync::Arc::new(progress_update_cb))
+                                        .await?,
+                                )
+                            })
+                        })
+                        .collect::<Result<futures::stream::FuturesUnordered<_>>>()?
+                        .collect::<Vec<_>>()
+                        .await,
                 )
-            })))
-            .map(|_v| ())
+            })?;
+
+            for r in res {
+                r?
+            }
+
+
+            anyhow::Result::Ok(())
         }
     }
 }

--- a/src/pipeline_processing/processing_graph.rs
+++ b/src/pipeline_processing/processing_graph.rs
@@ -1,0 +1,130 @@
+use anyhow::Result;
+use std::collections::{HashMap, HashSet};
+
+use crate::{
+    nodes::create_node_from_name,
+    pipeline_processing::{
+        node::{Node, NodeID, ProgressUpdate},
+        parametrizable::Parameters,
+        processing_context::ProcessingContext,
+    },
+};
+
+pub struct ProcessingNodeConfig {
+    name: String,
+    parameters: Parameters,
+    inputs: HashMap<String, usize>,
+}
+impl ProcessingNodeConfig {
+    pub fn single_input_node(name: String, parameters: Parameters, input: Option<NodeID>) -> Self {
+        ProcessingNodeConfig {
+            inputs: ["input".to_owned()].into_iter().zip(input.map(|v| v.into())).collect(),
+            parameters,
+            name,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct ProcessingGraph {
+    nodes: Vec<Option<ProcessingNodeConfig>>,
+}
+
+impl ProcessingGraph {
+    pub fn new() -> Self { Default::default() }
+
+    pub fn add(&mut self, config: ProcessingNodeConfig) -> NodeID {
+        let idx = self.nodes.len();
+        self.nodes.push(Some(config));
+        idx.into()
+    }
+
+    pub fn build(mut self, ctx: &ProcessingContext) -> Result<BuiltProcessingGraph> {
+        if self.nodes.is_empty() {
+            Ok(BuiltProcessingGraph { nodes: HashMap::new(), sinks: vec![] })
+        } else {
+            let mut is_input_to = HashMap::<_, Vec<_>>::new();
+
+            for (idx, node) in self.nodes.iter().enumerate() {
+                for input in node.as_ref().unwrap().inputs.values() {
+                    is_input_to.entry(*input).or_default().push(idx.into());
+                }
+            }
+
+
+            let mut built_nodes = HashMap::<_, Node>::new();
+            let mut avail: HashSet<_> = (1..self.nodes.len()).collect();
+            let mut queue = vec![0];
+            let mut sinks = vec![];
+
+            while !queue.is_empty() {
+                let idx = *queue.last().unwrap();
+                let mut missing = vec![];
+                let mut finished = HashMap::new();
+
+                let node = std::mem::take(&mut self.nodes[idx]).unwrap();
+
+                for (name, input_id) in &node.inputs {
+                    if let Some(node) = built_nodes.get(&(*input_id).into()) {
+                        finished.insert(name.clone(), node.clone());
+                    } else {
+                        missing.push(*input_id)
+                    }
+                }
+
+                if !missing.is_empty() {
+                    queue.append(&mut missing);
+                    self.nodes[idx] = Some(node);
+                } else {
+                    let built_node = create_node_from_name(
+                        &node.name,
+                        idx.into(),
+                        node.parameters,
+                        finished,
+                        is_input_to.entry(idx).or_default(),
+                        ctx,
+                    )?;
+                    if built_node.is_sink() {
+                        sinks.push(idx.into());
+                    }
+                    built_nodes.insert(idx.into(), built_node);
+
+
+                    avail.remove(&idx);
+                    queue.pop().unwrap();
+
+                    if queue.is_empty() && !avail.is_empty() {
+                        queue.push(*avail.iter().next().unwrap())
+                    }
+                }
+            }
+
+            Ok(BuiltProcessingGraph { nodes: built_nodes, sinks })
+        }
+    }
+}
+
+pub struct BuiltProcessingGraph {
+    nodes: HashMap<NodeID, Node>,
+    sinks: Vec<NodeID>,
+}
+
+impl BuiltProcessingGraph {
+    pub fn run<FUNC: Fn(ProgressUpdate) + Send + Sync + Clone + 'static>(
+        &self,
+        ctx: &ProcessingContext,
+        progress_update_cb: FUNC,
+    ) -> Result<()> {
+        if self.sinks.is_empty() {
+            Err(anyhow::anyhow!("processing graph should contain atleast one sink"))
+        } else {
+            pollster::block_on(futures::future::try_join_all(self.sinks.iter().map(|id| async {
+                let sink = self.nodes.get(id).unwrap().assert_sink()?;
+                anyhow::Result::Ok(
+                    sink.run(ctx, std::sync::Arc::new(progress_update_cb.clone())).await?,
+                )
+            })))
+            .map(|_v| ())
+        }
+    }
+}

--- a/src/pipeline_processing/puller.rs
+++ b/src/pipeline_processing/puller.rs
@@ -4,17 +4,13 @@ use crate::pipeline_processing::{
     processing_context::ProcessingContext,
 };
 use anyhow::Result;
-use futures::{stream::FuturesUnordered, StreamExt};
-use std::{
-    collections::VecDeque,
-    ops::Deref,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        mpsc::{sync_channel, Receiver, SendError},
-        Arc,
-    },
-    thread,
-    thread::JoinHandle,
+use futures::{
+    stream::{FuturesOrdered, FuturesUnordered},
+    StreamExt,
+};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
 };
 
 
@@ -26,23 +22,24 @@ pub async fn pull_unordered(
     on_payload: impl Fn(Payload, u64) -> Result<()> + Send + Sync + Clone + 'static,
 ) -> Result<()> {
     let mut range = match (number_of_frames, input.get_caps().frame_count) {
-        (0, None) => 0..u64::MAX,
-        (0, Some(n)) => 0..n,
-        (n, None) => 0..n,
-        (n, Some(m)) => 0..(n.min(m)),
+        (0, None) => 0..u32::MAX,
+        (0, Some(n)) => 0..(n as u32),
+        (n, None) => 0..(n as u32),
+        (n, Some(m)) => 0..((n as u32).min(m as u32)),
     };
 
-    let total_frames = if range.end == u64::MAX { None } else { Some(range.end) };
+    let total_frames = if range.end == u32::MAX { None } else { Some(range.end as _) };
 
     let latest_frame = Arc::new(AtomicU64::new(0));
     let mut futures_unordered = FuturesUnordered::new();
 
     loop {
-        if futures_unordered.len() >= context.num_threads() {
+        if range.is_empty() && futures_unordered.is_empty() {
+            break;
+        }
+        if range.is_empty() || futures_unordered.len() >= context.num_threads() {
             if let Some(result) = futures_unordered.next().await {
                 result?;
-            } else {
-                break;
             }
         }
         if let Some(frame) = range.next() {
@@ -52,12 +49,12 @@ pub async fn pull_unordered(
             let progress_callback = progress_callback.clone();
             let latest_frame = latest_frame.clone();
             futures_unordered.push(context.spawn(async move {
-                match input.pull(frame, &context_clone).await {
-                    Ok(pulled) => on_payload(pulled, frame)?,
+                match input.pull(frame as _, &context_clone).await {
+                    Ok(pulled) => on_payload(pulled, frame as _)?,
                     Err(e) => eprintln!("frame {} dropped. error:\n{:?}\n\n", frame, e),
                 }
 
-                let latest_frame = latest_frame.fetch_max(frame, Ordering::Relaxed);
+                let latest_frame = latest_frame.fetch_max(frame as _, Ordering::Relaxed);
                 progress_callback(ProgressUpdate { latest_frame, total_frames });
 
                 Ok::<(), anyhow::Error>(())
@@ -68,10 +65,76 @@ pub async fn pull_unordered(
     Ok(())
 }
 
+// TODO(robin): abort the thread when we want to stop
+pub fn pull_ordered(
+    context: &ProcessingContext,
+    progress_callback: Arc<dyn Fn(ProgressUpdate) + Send + Sync>,
+    input: InputProcessingNode,
+    number_of_frames: u64,
+) -> flume::Receiver<Payload> {
+    let mut range = match (number_of_frames, input.get_caps().frame_count) {
+        (0, None) => 0..u32::MAX,
+        (0, Some(n)) => 0..(n as u32),
+        (n, None) => 0..(n as u32),
+        (n, Some(m)) => 0..((n as u32).min(m as u32)),
+    };
+
+    let total_frames = if range.end == u32::MAX { None } else { Some(range.end as _) };
+
+    let latest_frame = Arc::new(AtomicU64::new(0));
+    let mut futures_ordered = FuturesOrdered::new();
+
+    let (tx, rx) = flume::bounded(context.num_threads());
+
+    let context = context.clone();
+    std::thread::spawn(move || {
+        context.block_on(async {
+            loop {
+                if range.is_empty() && futures_ordered.is_empty() {
+                    break;
+                }
+                if range.is_empty() || futures_ordered.len() >= context.num_threads() {
+                    if let Some(input) = futures_ordered.next().await {
+                        match input {
+                            (Ok(input), _) => tx.send_async(input).await.unwrap(),
+                            (Err(e), frame) => eprintln!("error pulling frame {frame}: {e}"),
+                        }
+                    }
+                }
+                if let Some(frame) = range.next() {
+                    let context_clone = context.clone();
+                    let input = input.clone_for_same_puller();
+                    let progress_callback = progress_callback.clone();
+                    let latest_frame = latest_frame.clone();
+                    futures_ordered.push(context.spawn(async move {
+                        let input = input.pull(frame as _, &context_clone).await;
+                        let latest_frame = latest_frame.fetch_max(frame as _, Ordering::Relaxed);
+                        progress_callback(ProgressUpdate { latest_frame, total_frames });
+
+                        (input, frame as u64)
+                    }));
+                }
+            }
+        })
+    });
+
+    rx
+}
+
+/*
 pub struct OrderedPuller {
     rx: Option<Receiver<Payload>>,
     join_handle: Option<JoinHandle<Result<()>>>,
 }
+
+/*
+ *
+    context: &ProcessingContext,
+    progress_callback: Arc<dyn Fn(ProgressUpdate) + Send + Sync>,
+    input: InputProcessingNode,
+    number_of_frames: u64,
+    on_payload: impl Fn(Payload, u64) -> Result<()> + Send + Sync + Clone + 'static,
+ * */
 
 impl OrderedPuller {
     pub fn new(
@@ -83,41 +146,10 @@ impl OrderedPuller {
         let (tx, rx) = sync_channel::<Payload>(context.num_threads());
         let context = context.clone();
         let join_handle = thread::spawn(move || {
-            let range = match (number_of_frames, input.get_caps().frame_count) {
-                (0, None) => 0..u64::MAX,
-                (0, Some(n)) => 0..n,
-                (n, None) => 0..n,
-                (n, Some(m)) => 0..(n.min(m)),
-            };
-
-            let mut range: Box<dyn Iterator<Item = u64>> =
-                if do_loop { Box::new(range.cycle()) } else { Box::new(range) };
-
-            let mut todo = VecDeque::with_capacity(context.num_threads());
-            loop {
-                while todo.len() < 10 {
-                    if let Some(frame) = range.next() {
-                        let context = context.for_frame(frame);
-                        let input = input.clone_for_same_puller();
-                        todo.push_front(
-                            context.clone().spawn(async move { input.pull(frame, &context).await }),
-                        );
-                    } else {
-                        break;
-                    }
-                }
-                if let Some(payload) = todo.pop_back() {
-                    match pollster::block_on(payload) {
-                        Ok(pulled) => match tx.send(pulled) {
-                            Ok(()) => {}
-                            Err(SendError(_)) => break,
-                        },
-                        Err(e) => eprintln!("frame dropped. error:\n{:?}\n\n", e),
-                    }
-                } else {
-                    break;
-                }
-            }
+            pollster::block_on(pull_ordered(&context, Arc::new(|_| {}), input, number_of_frames, move |input, frame_number| {
+                dbg!(frame_number);
+                Ok(tx.send(input)?)
+            }));
 
             Ok(())
         });
@@ -138,3 +170,4 @@ impl Deref for OrderedPuller {
 
     fn deref(&self) -> &Self::Target { self.rx.as_ref().unwrap() }
 }
+*/

--- a/src/util/async_notifier.rs
+++ b/src/util/async_notifier.rs
@@ -23,11 +23,7 @@ impl<T: Clone> AsyncNotifier<T> {
         predicate: impl Fn(&T) -> bool + 'static + Send + Sync,
     ) -> AsyncNotifierFuture<T> {
         let mut lock = self.0.lock().unwrap();
-        let data = if predicate(&lock.data) {
-            Some(lock.data.clone())
-        } else {
-            None
-        };
+        let data = if predicate(&lock.data) { Some(lock.data.clone()) } else { None };
 
         let fut = AsyncNotifierFuture(Arc::new(Mutex::new(AsyncNotifierFutureInner {
             waker: None,

--- a/src/util/fps_report.rs
+++ b/src/util/fps_report.rs
@@ -4,6 +4,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+#[derive(Clone)]
 pub struct FPSReporter {
     tx: SyncSender<()>,
 }


### PR DESCRIPTION
This adds support for specifying a yaml based config file that allows
one to build arbitrary processing graphs.

To allow multiple sinks to run simultaneously, they need to be converted
to be actually async (atleast on a frame by frame basis).

Furthermore, switch from pollster to tokio. Currently this is does not
really bring us anything, but maybe we can replace some of the manual
thread handling with spawn_blocking later. Also we can now use
`tokio-console` :)

Limitations:
- Display currently is no longer running on the main thread,
which breaks on windows and macos. To fix this, we should add window
management and event reception parts to the ProcessingContext which
forwards them to a EventLoop running in the main thread.
- No caching is implemented, which makes running multiple sinks that
share parts of the processing chain really inefficient or impossible (in
case of nodes that only allow forward progress like Average or
DualFrameRawDecoder). To fix this we should finally implement the
caching node, for which some ground work is already done in https://github.com/apertus-open-source-cinema/axiom-recorder/pull/27.